### PR TITLE
Add Blender 4.2 LTS to defaults

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -762,6 +762,29 @@
             "environment": "{}",
             "variants": [
                 {
+                    "name": "4-2",
+                    "label": "4.2 LTS",
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Blender Foundation\\Blender 4.2\\blender.exe"
+                        ],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "arguments": {
+                        "windows": [
+                            "--python-use-system-env"
+                        ],
+                        "darwin": [
+                            "--python-use-system-env"
+                        ],
+                        "linux": [
+                            "--python-use-system-env"
+                        ]
+                    },
+                    "environment": "{}"
+                },
+                {
                     "name": "3-6-5",
                     "label": "3.6.5 LTS",
                     "executables": {


### PR DESCRIPTION
The Blender 4.2 LTS version has been released: https://www.blender.org/download/

![image](https://github.com/user-attachments/assets/a7564214-63d3-46dc-b864-7d5530e40c78)

So this updates the default settings to include it.

### Testing notes

1. Test whether Blender 4.2 works as intended