### PR TITLE
Icons statics: Don't use version in local webserver path

### DIFF
--- a/client/ayon_applications/addon.py
+++ b/client/ayon_applications/addon.py
@@ -159,7 +159,7 @@ class ApplicationsAddon(AYONAddon, IPluginPaths):
         if not server_url:
             return None
         return "/".join([
-            server_url, "addons", self.name, self.version, "icons", icon_name
+            server_url, "addons", self.name, "icons", icon_name
         ])
 
     def get_applications_action_classes(self):
@@ -230,7 +230,7 @@ class ApplicationsAddon(AYONAddon, IPluginPaths):
             manager (WebServerManager): Webserver manager.
 
         """
-        static_prefix = f"/addons/{self.name}/{self.version}/icons"
+        static_prefix = f"/addons/{self.name}/icons"
         manager.add_static(
             static_prefix, os.path.join(APPLICATIONS_ADDON_ROOT, "icons")
         )


### PR DESCRIPTION
## Description
Don't use addon version when supplying statics on localhost.

## Additional information
To be able to use the uri one has to know which addon version is used, which is not really necessary for localhost, which has to run in tray, which can use only one version of an addon at a time.