### PR TITLE
add missing mayapy setting

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -148,6 +148,8 @@ class ApplicationsSettings(BaseSettingsModel):
 
     maya: AppGroupWithPython = SettingsField(
         default_factory=AppGroupWithPython, title="Autodesk Maya")
+    mayapy: AppGroupWithPython = SettingsField(
+        default_factory=AppGroupWithPython, title="Autodesk MayaPy")
     adsk_3dsmax: AppGroupWithPython = SettingsField(
         default_factory=AppGroupWithPython, title="Autodesk 3ds Max")
     flame: AppGroupWithPython = SettingsField(


### PR DESCRIPTION
## Changelog Description
Add missing mayapy setting.

## Additional info
I don't know if we should fix the missing mayapy setting or remove its definition from [applications.json](https://github.com/ynput/ayon-applications/blob/6db4c15c31b3dc7339f1db77868abe562db08be5/server/applications.json#L92-L140)


## Testing notes:
1. You should find mayapy in settings
2. Maybe try launching it from launcher (IDK)
