### PR TITLE
Harmony: Update env var to the new key name in recent ayon-harmony

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -811,7 +811,7 @@
             "label": "Harmony",
             "icon": "{}/app_icons/harmony.png",
             "host_name": "harmony",
-            "environment": "{\n    \"AVALON_HARMONY_WORKFILES_ON_LAUNCH\": \"1\"\n}",
+            "environment": "{\n    \"AYON_HARMONY_WORKFILES_ON_LAUNCH\": \"1\"\n}",
             "variants": [
                 {
                     "name": "22",


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Change `AVALON_HARMONY_WORKFILES_ON_LAUNCH` -> `AYON_HARMONY_WORKFILES_ON_LAUNCH`

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

See:
- https://github.com/ynput/ayon-harmony/blob/5a93fb2993d068cf2bfc95438c5eab55e4eba35b/client/ayon_harmony/api/lib.py#L201
- https://discord.com/channels/517362899170230292/563751989075378201/1267948379720257718


## Testing notes:

1. Defaults should be updated
2. Defaults should make sense with latest release of harmony.
