### PR TITLE
Chore: Addon method to modify envrionments is optional

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -202,7 +202,8 @@ def _add_python_version_paths(app, env, logger, addons_manager):
     """Add vendor packages specific for a Python version."""
 
     for addon in addons_manager.get_enabled_addons():
-        addon.modify_application_launch_arguments(app, env)
+        if hasattr(addon, "modify_application_launch_arguments"):
+            addon.modify_application_launch_arguments(app, env)
 
     # Skip adding if host name is not set
     if not app.host_name:


### PR DESCRIPTION
## Changelog Description
Method `modify_application_launch_arguments` is optional on addon. It should not be defined on B

## Additional info
The base addon class is defined in ayon-core which should not provide applications specific definition of the method.

## Testing notes:
Nothing really changes now. This PR makes the method optional, so future version of ayon-core can remove it from base addon class.
