### PR TITLE
Set applications "tools" being used as info log instead of debug

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -438,7 +438,7 @@ def prepare_app_environments(
             environments.append(tool.environment)
             app_and_tool_labels.append(tool.full_name)
 
-    log.debug(
+    log.info(
         "Will add environments for apps and tools: {}".format(
             ", ".join(app_and_tool_labels)
         )


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

It can sometimes be hard to 'debug' why certain tool configurations may or may not work - or even recognize whether the tools are even applied to your current environment or not. This change makes this log message appear in console by default when launching an application.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

I feel, especially with the change to new tools filtering with applications 1.0.0 having this available in logs will be helpful to debug.

## Testing notes:

1. Launch an app with applications.
2. Log should be visible in ayon console (where it previously wasn't by default).
