### PR TITLE
Profiles don't require profile without task types

### DIFF
--- a/server/actions.py
+++ b/server/actions.py
@@ -118,9 +118,8 @@ async def get_action_manifests(addon, project_name, variant):
             allowed_apps = list(profile["applications"])
 
         if not profile["task_types"]:
-            if generic_apps is not None:
-                continue
-            generic_apps = allowed_apps
+            if generic_apps is None:
+                generic_apps = allowed_apps
             continue
 
         task_types = set(profile["task_types"]) - used_task_types
@@ -137,7 +136,7 @@ async def get_action_manifests(addon, project_name, variant):
         for task_type in project_entity.task_types
     }
     generic_task_types = project_task_types - used_task_types
-    if generic_task_types:
+    if generic_task_types and generic_apps:
         for app_name in generic_apps:
             task_types_by_app_name[app_name] |= generic_task_types
 


### PR DESCRIPTION
## Changelog Description
Allow to not have profile without task types filtering.

## Testing notes:
1. Create pakcage, upload to server and use in your bundle.
2. Go to applications settings.
3. Either remove all profiles or have profiles with only task types filtering `ayon+settings://applications/project_applications/profiles`.
4. Webactions should work based on your profiles.
