### PR TITLE
Use variant name if label is not filled

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -7,7 +7,7 @@
             "variants": [
                 {
                     "name": "2025",
-                    "label": "2025",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Autodesk\\Maya2025\\bin\\maya.exe"
@@ -28,7 +28,7 @@
                 },
                 {
                     "name": "2024",
-                    "label": "2024",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Autodesk\\Maya2024\\bin\\maya.exe"
@@ -49,7 +49,7 @@
                 },
                 {
                     "name": "2023",
-                    "label": "2023",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Autodesk\\Maya2023\\bin\\maya.exe"
@@ -116,7 +116,7 @@
             "variants": [
                 {
                     "name": "2021",
-                    "label": "2021",
+                    "label": "",
                     "executables": {
                         "windows": [],
                         "darwin": [
@@ -578,7 +578,7 @@
             "variants": [
                 {
                     "name": "18",
-                    "label": "18",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Blackmagic Design\\Fusion 18\\Fusion.exe"
@@ -595,7 +595,7 @@
                 },
                 {
                     "name": "17",
-                    "label": "17",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Blackmagic Design\\Fusion 17\\Fusion.exe"
@@ -619,7 +619,7 @@
             "variants": [
                 {
                     "name": "stable",
-                    "label": "stable",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:/Program Files/Blackmagic Design/DaVinci Resolve/Resolve.exe"
@@ -775,7 +775,7 @@
             "variants": [
                 {
                     "name": "22",
-                    "label": "22",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "c:\\Program Files (x86)\\Toon Boom Animation\\Toon Boom Harmony 22 Premium\\win64\\bin\\HarmonyPremium.exe"
@@ -794,7 +794,7 @@
                 },
                 {
                     "name": "21",
-                    "label": "21",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "c:\\Program Files (x86)\\Toon Boom Animation\\Toon Boom Harmony 21 Premium\\win64\\bin\\HarmonyPremium.exe"
@@ -861,7 +861,7 @@
             "variants": [
                 {
                     "name": "2023",
-                    "label": "2023",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Adobe\\Adobe Photoshop 2023\\Photoshop.exe"
@@ -880,7 +880,7 @@
                 },
                 {
                     "name": "2024",
-                    "label": "2024",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Adobe\\Adobe Photoshop 2024\\Photoshop.exe"
@@ -925,7 +925,7 @@
             "variants": [
                 {
                     "name": "2023",
-                    "label": "2023",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Adobe\\Adobe After Effects 2023\\Support Files\\AfterFX.exe"
@@ -944,7 +944,7 @@
                 },
                 {
                     "name": "2024",
-                    "label": "2024",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Adobe\\Adobe After Effects 2024\\Support Files\\AfterFX.exe"
@@ -989,7 +989,7 @@
             "variants": [
                 {
                     "name": "local",
-                    "label": "local",
+                    "label": "",
                     "executables": {
                         "windows": [],
                         "darwin": [],
@@ -1179,7 +1179,7 @@
             "variants": [
                 {
                     "name": "2025",
-                    "label": "2025",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Autodesk\\MotionBuilder 2025\\bin\\x64\\motionbuilder.exe"
@@ -1191,7 +1191,7 @@
                 },
                 {
                     "name": "2024",
-                    "label": "2024",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Autodesk\\MotionBuilder 2024\\bin\\x64\\motionbuilder.exe"

--- a/server/settings.py
+++ b/server/settings.py
@@ -62,7 +62,6 @@ async def applications_enum(
     apps_fields = apps_settings.__fields__
     apps_groups = set(apps_fields.keys())
     apps_groups.discard("additional_apps")
-    # apps_dict.update(apps_settings.additional_apps.dict().items())
     all_variants_by_group_label = {}
     for group_name in apps_groups:
         app_group = getattr(apps_settings, group_name)
@@ -136,11 +135,11 @@ async def tools_enum(
 
     enum_variants = []
     for tool_group in settings.tool_groups:
-        group_label = tool_group.label
         group_name = tool_group.name
+        group_label = tool_group.label or group_name
         enum_variants.extend([
             {
-                "label": f"{group_label} {variant.label}",
+                "label": f"{group_label} {variant.label or variant.name}",
                 "value": f"{group_name}/{variant.name}",
             }
             for variant in tool_group.variants

--- a/server/settings.py
+++ b/server/settings.py
@@ -79,13 +79,13 @@ async def applications_enum(
         group_label = app_field.field_info.title
 
         app_variants = list(app_group.variants)
-        app_variants.sort(key=lambda x: x.label, reverse=True)
+        app_variants.sort(key=lambda x: x.label or x.name, reverse=True)
         enum_variants = all_variants_by_group_label.setdefault(
             group_label, []
         )
         enum_variants.extend([
             {
-                "label": f"{group_label} {variant.label}",
+                "label": f"{group_label} {variant.label or variant.name}",
                 "value": f"{group_name}/{variant.name}",
             }
             for variant in app_variants
@@ -104,13 +104,13 @@ async def applications_enum(
         if not group_label:
             group_label = group_name
 
-        app_variants.sort(key=lambda x: x.label, reverse=True)
+        app_variants.sort(key=lambda x: x.label or x.name, reverse=True)
         enum_variants = all_variants_by_group_label.setdefault(
             group_label, []
         )
         enum_variants.extend([
             {
-                "label": f"{group_label} {variant.label}",
+                "label": f"{group_label} {variant.label or variant.name}",
                 "value": f"{group_name}/{variant.name}",
             }
             for variant in app_variants


### PR DESCRIPTION
## Changelog Description
Don't require `label` filled on application and tool variant.

## Additional info
Also removed labels that are same as name.

## Testing notes:
1. Create package, upload to server and add to your bundle.
2. Go to settings, remove application or tool variant label and save settings.
3. Both applications and tools selection combobox should use variant name as variant label.

Resolves https://github.com/ynput/ayon-applications/issues/28