### PR TITLE
Webactions: Skip disabled applications

### DIFF
--- a/server/actions.py
+++ b/server/actions.py
@@ -87,6 +87,8 @@ async def get_action_manifests(addon, project_name, variant):
     app_settings = addon_settings["applications"]
     app_groups = app_settings.pop("additional_apps")
     for group_name, value in app_settings.items():
+        if not value["enabled"]:
+            continue
         value["name"] = group_name
         app_groups.append(value)
 


### PR DESCRIPTION
## Changelog Description
Disabled applications are not shown in webactions.

## Additional info
When profile specified that all applications should be visible based on profile filters, it showed even disabled applications.

## Testing notes:
1. Create package, upload it to AYON and add it to bundle.
2. Create profile in applications profiles to show all applications.
3. Only enabled applications should be shown on selected task.

Resolves https://github.com/ynput/ayon-applications/issues/26