### PR TITLE
Default settings: VRay Maya has maya host

### DIFF
--- a/server/tools.json
+++ b/server/tools.json
@@ -121,7 +121,7 @@
                     "name": "6.10.01",
                     "label": "",
                     "host_names": [
-                        ""
+                        "maya"
                     ],
                     "environment": "{\n    \"VRAY_VERSION\": \"6.10.01\"\n}",
                     "app_variants": []


### PR DESCRIPTION
## Changelog Description
Example VRay Maya tool have invalid hosts filter.

## Additional info
There was invalid filter for hosts with `""` in host names filter.

## Testing notes:
1. Validate changes.
