### PR TITLE
Fill environment variables for farm jobs

### DIFF
--- a/client/ayon_applications/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_applications/plugins/publish/collect_farm_env_variables.py
@@ -1,0 +1,26 @@
+import os
+
+import pyblish.api
+
+try:
+    from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+except ImportError:
+    # NOTE Can be removed when ayon-core >= 1.0.10 is required in package.py
+    FARM_JOB_ENV_DATA_KEY = "farmJobEnv"
+
+
+class CollectApplicationsJobEnvVars(pyblish.api.ContextPlugin):
+    """Collect set of environment variables to submit with deadline jobs"""
+    order = pyblish.api.CollectorOrder - 0.45
+    label = "Collect Applications farm environment variables"
+    targets = ["local"]
+
+    def process(self, context):
+        env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+        for key in [
+            "AYON_APP_NAME",
+        ]:
+            value = os.getenv(key)
+            if value:
+                self.log.debug(f"Setting job env: {key}: {value}")
+                env[key] = value

--- a/client/ayon_applications/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_applications/plugins/publish/collect_farm_env_variables.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 class CollectApplicationsJobEnvVars(pyblish.api.ContextPlugin):
-    """Collect set of environment variables to submit with deadline jobs"""
+    """Collect set of environment variables for farm jobs"""
     order = pyblish.api.CollectorOrder - 0.45
     label = "Collect Applications farm environment variables"
     targets = ["local"]


### PR DESCRIPTION
## Changelog Description
Fill environment variables for farm in publish plugins.

## Additional review information
Move control to collect applications environment variables, needed for farm jobs, to applications addon.

## Testing notes:
1. At this moment probably nothing changed because deadline has to stop auto-fill the key.

Resolves https://github.com/ynput/ayon-applications/issues/41