### PR TITLE
Log opening of last workfile was disabled only if `start_last_workfile is False` explicitly

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -679,7 +679,7 @@ def _prepare_last_workfile(data, workdir, addons_manager):
         start_last_workfile = should_use_last_workfile_on_launch(
             project_name, app.host_name, task_name, task_type
         )
-    else:
+    elif start_last_workfile is False:
         log.info("Opening of last workfile was disabled by user")
 
     data["start_last_workfile"] = start_last_workfile


### PR DESCRIPTION
## Changelog Description

Log opening of last workfile was disabled only if `start_last_workfile is False` explicitly

## Additional review information

Do not log this message if the last workfile was actually to be opened.

## Testing notes:

1. Start e.g. Blender with last workfile enabled.
2. The `Opening of last workfile was disabled by user` should not appear in the logs.
