### PR TITLE
Remove 3dsmax addon directory enviroment

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -73,7 +73,7 @@
         "adsk_3dsmax": {
             "enabled": true,
             "host_name": "max",
-            "environment": "",
+            "environment": "{}",
             "variants": [
                 {
                     "name": "2024",

--- a/server/applications.json
+++ b/server/applications.json
@@ -73,7 +73,7 @@
         "adsk_3dsmax": {
             "enabled": true,
             "host_name": "max",
-            "environment": "{\n    \"ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR\": \"{OPENPYPE_ROOT}/openpype/hosts/max/startup\"\n}",
+            "environment": "",
             "variants": [
                 {
                     "name": "2024",


### PR DESCRIPTION
## Changelog Description
Remove 3dsmax addon directory environment as default setting regarding to https://github.com/ynput/ayon-3dsmax/pull/34

## Additional review information
n/

## Testing notes:
1. Build and install application addon alongside the Max addon built with https://github.com/ynput/ayon-3dsmax/pull/34
2. Launch Max
3. AYON plugins should be installed and working successfully.
