### PR TITLE
Chore: Use env tools functions from ayon core

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -31,6 +31,7 @@ from .manager import ApplicationManager
 # NOTE Remove try -> except block, when ayon-core > 1.1.1 is required,
 #   or require the version to remove it.
 try:
+    # Was introduced in ayon-core 1.1.2
     from ayon_core.lib import (
         merge_env_variables,
         compute_env_variables_structure,


### PR DESCRIPTION
## Changelog Description
Use `merge_env_variables` and `compute_env_variables_structure` from ayon-core repository if are available.

## Additional review information
The fallbacks should be removed after some time, which will require bump compatible version of ayon-core.

## Testing notes:
1. Test with latest ayon-core.
2. Make sure your task is using tools that have env variables to resolve.
3. The environments of application and tools should be resolved as before.
