### PR TITLE
Add Blender 4.4 to defaults

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -790,6 +790,31 @@
                         ]
                     },
                     "environment": "{}"
+                },
+                {
+                    "name": "4-4",
+                    "label": "4.4",
+                    "executables": {
+                        "linux": [],
+                        "darwin": [
+                            "/Applications/Blender.app"
+                        ],
+                        "windows": [
+                            "C:\\Program Files\\Blender Foundation\\Blender 4.4\\blender.exe"
+                        ]
+                    },
+                    "arguments": {
+                        "windows": [
+                            "--python-use-system-env"
+                        ],
+                        "darwin": [
+                            "--python-use-system-env"
+                        ],
+                        "linux": [
+                            "--python-use-system-env"
+                        ]
+                    },
+                    "environment": "{\n    \"AYON_BLENDER_USE_SYSTEM_PATH\": \"1\"\n}"
                 }
             ]
         },


### PR DESCRIPTION
## Changelog Description

Add Blender 4.4 to defaults

## Additional review information

Include `AYON_BLENDER_USE_SYSTEM_PATH` in variant environment, for more details see: https://github.com/ynput/ayon-blender/pull/103
Requires `ayon-blender 0.2.10`

## Testing notes:

1. Launching Blender 4.4 should work with these defaults
