### PR TITLE
Add Fusion 19 and 20 to defaults

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -594,6 +594,40 @@
             "environment": "{\n    \"FUSION_PYTHON3_HOME\": {\n        \"windows\": \"{LOCALAPPDATA}/Programs/Python/Python39\",\n        \"darwin\": \"~/Library/Python/3.9/bin\",\n        \"linux\": \"/opt/Python/3.9/bin\"\n    }\n}",
             "variants": [
                 {
+                    "name": "20",
+                    "label": "",
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Blackmagic Design\\Fusion 20\\Fusion.exe"
+                        ],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "arguments": {
+                        "windows": [],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{}"
+                },
+                {
+                    "name": "19",
+                    "label": "",
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Blackmagic Design\\Fusion 19\\Fusion.exe"
+                        ],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "arguments": {
+                        "windows": [],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{}"
+                },
+                {
                     "name": "18",
                     "label": "",
                     "executables": {


### PR DESCRIPTION
## Changelog Description

Add Fusion 19 and 20 to defaults

## Additional review information

Note that Fusion 20 is currently in public beta still.
Also, Fusion 20 requires[ this fix in `ayon-fusion`](https://github.com/ynput/ayon-fusion/pull/41).

## Testing notes:

1. Fusion 19 and 20 should work with the new defaults
