### PR TITLE
Debug terminal: Add check for icon value

### DIFF
--- a/client/ayon_applications/plugins/launcher_actions/debug_terminal.py
+++ b/client/ayon_applications/plugins/launcher_actions/debug_terminal.py
@@ -25,7 +25,7 @@ def get_application_qt_icon(application: Application) -> Optional[QtGui.QIcon]:
     if not icon:
         return QtGui.QIcon()
     icon_filepath = get_app_icon_path(icon)
-    if os.path.exists(icon_filepath):
+    if icon_filepath and os.path.exists(icon_filepath):
         return get_qt_icon({"type": "path", "path": icon_filepath})
     return QtGui.QIcon()
 


### PR DESCRIPTION
## Changelog Description
Fix check of icon filepath value.

## Additional review information
Make sure `None` is not passed into `os.path.exists`.

## Testing notes:
1. Add custom application in studio settings.
2. Add the application to applications list (or use `All applications).
3. Debug terminal does not cause crashes when launched.

Resolves https://github.com/ynput/ayon-applications/issues/65