### PR TITLE
Webactions: Use project settings for applications list

### DIFF
--- a/server/actions.py
+++ b/server/actions.py
@@ -86,7 +86,9 @@ async def get_action_manifests(addon, project_name, variant):
     if not project_name:
         return []
 
-    settings_model = await addon.get_studio_settings(variant=variant)
+    settings_model = await addon.get_project_settings(
+        project_name, variant=variant
+    )
     addon_settings = settings_model.dict()
 
     app_settings = addon_settings["applications"]


### PR DESCRIPTION
## Changelog Description
Use project based settings for applications webactions.

## Testing notes:
1. Applications list in project settings are respected in webactions.

Resolves https://github.com/ynput/ayon-applications/issues/55
