### PR TITLE
Webactions: Add group labels

### DIFF
--- a/server/actions.py
+++ b/server/actions.py
@@ -13,6 +13,11 @@ except ImportError:
 from .constants import LABELS_BY_GROUP_NAME, ICONS_BY_GROUP_NAME
 
 IDENTIFIER_PREFIX = "application.launch."
+_manifest_fields = getattr(SimpleActionManifest, "__fields__", None)
+if _manifest_fields is None:
+    _manifest_fields = getattr(SimpleActionManifest, "model_fields", set)()
+
+_GROUP_LABEL_AVAILABLE = "group_label" in _manifest_fields
 
 
 def _sort_getter(item):
@@ -60,7 +65,7 @@ def get_items_for_app_groups(groups):
 def _prepare_label_kwargs(item):
     group_label = item["group_label"]
     variant_label = item["variant_label"]
-    if hasattr(SimpleActionManifest, "group_label"):
+    if _GROUP_LABEL_AVAILABLE:
         return {
             "label": variant_label,
             "group_label": group_label,

--- a/server/actions.py
+++ b/server/actions.py
@@ -13,10 +13,11 @@ except ImportError:
 from .constants import LABELS_BY_GROUP_NAME, ICONS_BY_GROUP_NAME
 
 IDENTIFIER_PREFIX = "application.launch."
+
 _manifest_fields = getattr(SimpleActionManifest, "__fields__", None)
 if _manifest_fields is None:
     _manifest_fields = getattr(SimpleActionManifest, "model_fields", set)()
-
+# Backwards compatibility for AYON server older than 1.8.0
 _GROUP_LABEL_AVAILABLE = "group_label" in _manifest_fields
 
 

--- a/server/actions.py
+++ b/server/actions.py
@@ -15,9 +15,12 @@ from .constants import LABELS_BY_GROUP_NAME, ICONS_BY_GROUP_NAME
 IDENTIFIER_PREFIX = "application.launch."
 
 
+def _sort_getter(item):
+    return item["group_label"], item["variant_label"]
+
+
 def get_items_for_app_groups(groups):
-    label_by_name = {}
-    icon_by_name = {}
+    items = []
     for group in groups:
         group_name = group["name"]
         group_label = group.get(
@@ -43,18 +46,29 @@ def get_items_for_app_groups(groups):
                 continue
             variant_label = variant["label"] or variant_name
             full_name = f"{group_name}/{variant_name}"
-            full_label = f"{group_label} {variant_label}"
-            label_by_name[full_name] = full_label
-            icon_by_name[full_name] = icon
+            items.append({
+                "value": full_name,
+                "group_label": group_label,
+                "variant_label": variant_label,
+                "icon": icon,
+            })
 
-    return [
-        {
-            "value": full_name,
-            "label": label_by_name[full_name],
-            "icon": icon_by_name[full_name],
+    items.sort(key=_sort_getter)
+    return items
+
+
+def _prepare_label_kwargs(item):
+    group_label = item["group_label"]
+    variant_label = item["variant_label"]
+    if hasattr(SimpleActionManifest, "group_label"):
+        return {
+            "label": variant_label,
+            "group_label": group_label,
         }
-        for full_name in sorted(label_by_name)
-    ]
+
+    return {
+        "label": f"{group_label} {variant_label}",
+    }
 
 
 async def _get_action_manifests_with_attributes(app_groups, project_entity):
@@ -66,11 +80,10 @@ async def _get_action_manifests_with_attributes(app_groups, project_entity):
         app_full_name = item["value"]
         if app_full_name not in project_apps:
             continue
-
         output.append(
             SimpleActionManifest(
                 identifier=f"{IDENTIFIER_PREFIX}{app_full_name}",
-                label=item["label"],
+                **_prepare_label_kwargs(item),
                 category="Applications",
                 icon=item["icon"],
                 order=100,
@@ -166,7 +179,7 @@ async def get_action_manifests(addon, project_name, variant):
         output.append(
             SimpleActionManifest(
                 identifier=f"{IDENTIFIER_PREFIX}{app_name}",
-                label=app_item["label"],
+                **_prepare_label_kwargs(app_item),
                 category="Applications",
                 icon=app_item["icon"],
                 order=100,


### PR DESCRIPTION
## Changelog Description
Webactions are using group labels.

## Additional review information
The changes are backwards compatible so it works with AYON server below and above 1.8.0 .

This change is important for https://github.com/ynput/ayon-core/pull/1226 .

EDITED: This PR would break Web UI actions before this PR https://github.com/ynput/ayon-frontend/pull/1162  which is not yet in any release.

## Testing notes:
- For now nothing should change.
- When used with https://github.com/ynput/ayon-core/pull/1226 the application actions in launcher tool are grouped by DCC.
