### PR TITLE
Webaction: Use new executor function to run launcher action

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -124,7 +124,9 @@ class ApplicationsAddon(BaseServerAddon):
             args.extend([
                 "--use-last-workfile", str(int(not skip_last_workfile))
             ])
-
+        if hasattr(executor, "get_launcher_response"):
+            return await executor.get_launcher_response(args=args)
+        # Keep for backwards compatibility
         return await executor.get_launcher_action_response(args=args)
 
     async def get_default_settings(self):

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -124,9 +124,10 @@ class ApplicationsAddon(BaseServerAddon):
             args.extend([
                 "--use-last-workfile", str(int(not skip_last_workfile))
             ])
+        # 'get_launcher_response' is available since AYON 1.8.3
         if hasattr(executor, "get_launcher_response"):
             return await executor.get_launcher_response(args=args)
-        # Keep for backwards compatibility
+        # Backwards compatibility
         return await executor.get_launcher_action_response(args=args)
 
     async def get_default_settings(self):


### PR DESCRIPTION
## Changelog Description
Use new `get_launcher_response` on executor instead of `get_launcher_action_response`.

## Testing notes:
1. Webactions still do work with AYON server lower than 1.8.3 and newer than 1.8.3 .
