### PR TITLE
Chore: Change order of actions to to '0'

### DIFF
--- a/server/actions.py
+++ b/server/actions.py
@@ -188,7 +188,7 @@ async def get_action_manifests(addon, project_name, variant):
                 **_prepare_label_kwargs(app_item),
                 category="Applications",
                 icon=app_item["icon"],
-                order=100,
+                order=0,
                 entity_type="task",
                 entity_subtypes=list(task_types),
                 allow_multiselection=False,


### PR DESCRIPTION
## Changelog Description
Change order of applications webaction to `0`.

## Testing notes:
1. Webactions are sorted earlier with https://github.com/ynput/ayon-core/pull/1226 .
