### PR TITLE
Add 'Environment' JSON validation to settings

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -215,6 +215,10 @@ class AppGroup(BaseSettingsModel):
         ensure_unique_names(value)
         return value
 
+    @validator("environment")
+    def validate_json(cls, value):
+        return validate_json_dict(value)
+
 
 class AdditionalAppGroup(BaseSettingsModel):
     enabled: bool = SettingsField(True)
@@ -237,6 +241,10 @@ class AdditionalAppGroup(BaseSettingsModel):
     def validate_unique_name(cls, value):
         ensure_unique_names(value)
         return value
+
+    @validator("environment")
+    def validate_json(cls, value):
+        return validate_json_dict(value)
 
 
 class ToolVariantModel(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description

Add Environment field JSON validation in more places to avoid invalid JSON values being saved by an admin

## Additional review information

This already existed in most places, but lacked in some - which still allowed you to break the settings for launching an application.

## Testing notes:

1. Try any of the "Environment" attributes in Applications addon, and set up invalid JSON values. It should be disallowed to save invalid values.
