### PR TITLE
Removed limiting MULTIPROCESS default for Adobe products

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -1045,7 +1045,7 @@
                         "darwin": [],
                         "linux": []
                     },
-                    "environment": "{\n  \"MULTIPROCESS\": \"No\"\n}"
+                    "environment": "{}"
                 },
                 {
                     "name": "2024",
@@ -1064,7 +1064,7 @@
                         "darwin": [],
                         "linux": []
                     },
-                    "environment": "{\n  \"MULTIPROCESS\": \"No\"\n}"
+                    "environment": "{}"
                 },
                 {
                     "name": "2025",
@@ -1083,7 +1083,7 @@
                         "darwin": [],
                         "linux": []
                     },
-                    "environment": "{\n  \"MULTIPROCESS\": \"No\"\n}"
+                    "environment": "{}"
                 }
             ]
         },
@@ -1109,7 +1109,7 @@
                         "darwin": [],
                         "linux": []
                     },
-                    "environment": "{\n  \"MULTIPROCESS\": \"No\"\n}"
+                    "environment": "{}"
                 },
                 {
                     "name": "2024",
@@ -1128,7 +1128,7 @@
                         "darwin": [],
                         "linux": []
                     },
-                    "environment": "{\n  \"MULTIPROCESS\": \"No\"\n}"
+                    "environment": "{}"
                 },
                 {
                     "name": "2025",
@@ -1147,7 +1147,7 @@
                         "darwin": [],
                         "linux": []
                     },
-                    "environment": "{\n  \"MULTIPROCESS\": \"No\"\n}"
+                    "environment": "{}"
                 }
             ]
         },


### PR DESCRIPTION
## Changelog Description
Newer versions of adobe products shouldn't have issues with using `multiprocess` (or `Multi-Frame Rendering`) on Deadline.
This could bring some performance gains.

## Additional review information
If any particular variant of (mostly) AfterEffects would have issues with it, `MULTIPROCESS` env var could be still used to toggle it off.

Additional details https://github.com/ynput/OpenPype/pull/2748

## Testing notes:
1. test together with https://github.com/ynput/ayon-deadline/pull/185
2. publish via Deadline
