### PR TITLE
Environemnts: Store app tools to env variable on launch

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -453,12 +453,12 @@ def prepare_app_environments(
     # Add tools environments
     groups_by_name = {}
     tool_by_group_name = collections.defaultdict(dict)
-    used_tool_names = set()
+    used_tool_names = []
     for key in tools:
         tool = app.manager.tools.get(key)
         if not tool or not tool.is_valid_for_app(app):
             continue
-        used_tool_names.add(tool.full_name)
+        used_tool_names.append(tool.full_name)
         groups_by_name[tool.group.name] = tool.group
         tool_by_group_name[tool.group.name][tool.name] = tool
 

--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -453,10 +453,12 @@ def prepare_app_environments(
     # Add tools environments
     groups_by_name = {}
     tool_by_group_name = collections.defaultdict(dict)
+    used_tool_names = set()
     for key in tools:
         tool = app.manager.tools.get(key)
         if not tool or not tool.is_valid_for_app(app):
             continue
+        used_tool_names.add(tool.full_name)
         groups_by_name[tool.group.name] = tool.group
         tool_by_group_name[tool.group.name][tool.name] = tool
 
@@ -517,6 +519,7 @@ def prepare_app_environments(
     data["env"].update(final_env)
     for key in keys_to_remove:
         data["env"].pop(key, None)
+    data["env"]["AYON_APP_TOOLS"] = ";".join(used_tool_names)
 
 
 def apply_project_environments_value(


### PR DESCRIPTION
## Changelog Description
Store used tools into `AYON_APP_TOOLS` environment variable.

## Additional review information
The tool names are joined with a `;`. It is stored for information purposes to be stored to workfile entities (for example).

## Testing notes:
1. Launching of application will set up `AYON_APP_TOOLS` with used tools.
