### PR TITLE
Chore: cleanup workfiles startup env vars

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -876,7 +876,7 @@
         "harmony": {
             "enabled": true,
             "host_name": "harmony",
-            "environment": "",
+            "environment": "{}",
             "variants": [
                 {
                     "name": "22",


### PR DESCRIPTION
## Changelog Description
Removed control of opening of Workfiles app with environment variable. Replaced by control in `ayon-core` `ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup` which provides more granular control.

## Testing notes:
1. all Adobe products and Harmony shouldn't have any `*WORKFILES_ON_LAUNCH` in Environments.

