### PR TITLE
add `get_process_info_by_pid`

### DIFF
--- a/client/ayon_applications/process.py
+++ b/client/ayon_applications/process.py
@@ -268,17 +268,15 @@ class ProcessManager:
             created_at=row[9],
         )
 
-    def get_process_info_by_pid(self, pid: int = 0) -> Optional[ProcessInfo]:
+    def get_process_info_by_pid(self, pid: int) -> Optional[ProcessInfo]:
         """Get process information by process id.
 
         Args:
-            pid (int): ID of the process. (defaults to os.getpid())
+            pid (int): ID of the process.
 
         Returns:
             Optional[ProcessInfo]: Process information or None if not found.
         """
-        pid = pid or os.getpid()
-
         cnx = self._get_process_storage_connection()
         cursor = cnx.cursor()
         query = "SELECT * FROM process_info WHERE pid = ?"
@@ -300,6 +298,14 @@ class ProcessManager:
             start_time=row[8],
             created_at=row[9],
         )
+
+    def get_current_process_info(self) -> Optional[ProcessInfo]:
+        """Get information for the current process.
+
+        Returns:
+            Optional[ProcessInfo]: Process information or None if not found.
+        """
+        return self.get_process_info_by_pid(os.getpid())
 
     def get_all_process_info(self) -> list[ProcessInfo]:
         """Get all process information from the database.


### PR DESCRIPTION
## Changelog Description
Implemented a new helper function `get_process_info_by_pid` to access `ProcessInfo` via a Process ID.
This is based on `get_process_info_by_name` with just the respective args and query adjusted.

## Use Cases:
This function is particularly useful when running multiple instances of the same application. It allows for unique access to the `ProcessInfo` of a specific instance or the current session based on its PID.


## Testing notes:
```py
import os
from ayon_applications import process

# Access the process info by PID
manager = process.ProcessManager()
info = manager.get_process_info_by_pid(os.getpid())
print(info)
```
