### PR TITLE
Chore: Safe guard workdir creation

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -660,7 +660,7 @@ def prepare_context_environments(
     if not os.path.exists(workdir):
         log.debug(f"Creating workdir folder: \"{workdir}\"")
         try:
-            os.makedirs(workdir)
+            os.makedirs(workdir, exist_ok=True)
         except Exception as exc:
             raise ApplicationLaunchFailed(
                 f"Couldn't create workdir because: {exc}"


### PR DESCRIPTION
## Changelog Description
Use safe guarded workdir creation.

## Additional review information
There are cases when `os.path.exists` returns `False` even tho the directory exists (don't ask me how please).

## Testing notes:
Really don't know how to test.
