### PR TITLE
Move Process Monitor to Admin section in AYON tray

### DIFF
--- a/client/ayon_applications/addon.py
+++ b/client/ayon_applications/addon.py
@@ -48,6 +48,7 @@ class ApplicationsAddon(AYONAddon, IPluginPaths, ITrayAction):
 
     name = "applications"
     version = __version__
+    admin_action = True
 
     def tray_init(self) -> None:
         """Initialize the tray action."""


### PR DESCRIPTION
## Changelog Description

Move Process Monitor to Admin section in AYON tray

## Additional review information

[Came up internally](https://discord.com/channels/517362899170230292/1136202513402581006/1446726794186195086) that this should be an admin action.

<img width="275" height="232" alt="image" src="https://github.com/user-attachments/assets/7dbd3ace-92b2-4394-b73b-8c4050dd8e0d" />

Fix #121 


## Testing notes:

1. Process Monitor should be in admin submenu.
