### PR TITLE
Add syntax highlighting to "environment"-text fields

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -191,7 +191,10 @@ class AppVariant(BaseSettingsModel):
         default_factory=MultiplatformStrList, title="Arguments"
     )
     environment: str = SettingsField(
-        "{}", title="Environment", widget="textarea"
+        default="{}",
+        title="Environment",
+        widget="textarea",
+        syntax="json",
     )
     redirect_output: bool = SettingsField(
         default=True, title="Redirect output to Process Monitor",
@@ -211,7 +214,10 @@ class AppGroup(BaseSettingsModel):
     enabled: bool = SettingsField(True)
     host_name: str = SettingsField("", title="Host name")
     environment: str = SettingsField(
-        "{}", title="Environment", widget="textarea"
+        default="{}",
+        title="Environment",
+        widget="textarea",
+        syntax="json",
     )
 
     variants: list[AppVariant] = SettingsField(
@@ -238,7 +244,10 @@ class AdditionalAppGroup(BaseSettingsModel):
     host_name: str = SettingsField("", title="Host name")
     icon: str = SettingsField("", title="Icon")
     environment: str = SettingsField(
-        "{}", title="Environment", widget="textarea"
+        default="{}",
+        title="Environment",
+        widget="textarea",
+        syntax="json",
     )
 
     variants: list[AppVariant] = SettingsField(
@@ -269,7 +278,10 @@ class ToolVariantModel(BaseSettingsModel):
         enum_resolver=applications_enum,
     )
     environment: str = SettingsField(
-        "{}", title="Environments", widget="textarea"
+        default="{}",
+        title="Environments",
+        widget="textarea",
+        syntax="json",
     )
 
     @validator("environment")
@@ -281,7 +293,10 @@ class ToolGroupModel(BaseSettingsModel):
     name: str = SettingsField("", title="Name")
     label: str = SettingsField("", title="Label")
     environment: str = SettingsField(
-        "{}", title="Environments", widget="textarea"
+        default="{}",
+        title="Environments",
+        widget="textarea",
+        syntax="json",
     )
     variants: list[ToolVariantModel] = SettingsField(default_factory=list)
 


### PR DESCRIPTION
## Changelog Description
enables `json` syntax highlighting on all "environment" fields

## Additional review information
to be fair the result is not as helpful as I had imagined (json syntax is very single coloured)
BUT: it does help to identify some issues such as unclosed strings.

<img width="971" height="1162" alt="image" src="https://github.com/user-attachments/assets/9515cdfe-9367-44bb-96fa-e496fbc39e25" />

## follow up suggestion:

it might be nice to alter the theme slightly. for example changing the "gutter-mark" color to make it easier to spot the punctuation characters:
<img width="707" height="577" alt="image" src="https://github.com/user-attachments/assets/edd266a8-9f1f-4616-be04-cbea1f4e5cf3" />




