### PR TITLE
tbd: allow json with comments and trailing commas

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -1,5 +1,4 @@
 import os
-import json
 from pydantic import validator
 
 from ayon_server.addons import BaseServerAddon
@@ -10,6 +9,14 @@ from ayon_server.settings import (
     task_types_enum,
 )
 from ayon_server.exceptions import BadRequestException
+
+try:
+    import json5 as json
+    JSON_SYNTAX = "json5"
+except ImportError:
+    import json
+    JSON_SYNTAX = "json"
+
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 ICONS_DIR = os.path.join(
@@ -163,15 +170,16 @@ def validate_json_dict(value):
         return "{}"
     try:
         converted_value = json.loads(value)
-        success = isinstance(converted_value, dict)
-    except json.JSONDecodeError as exc:
-        print(exc)
-        success = False
-
-    if not success:
+        if not isinstance(converted_value, dict):
+            raise BadRequestException(
+                f"Environment must be a JSON object, "
+                f"got {type(converted_value).__name__}"
+            )
+    except ValueError as exc:
         raise BadRequestException(
-            "Environment's can't be parsed as json object"
+            f"Environment can't be parsed as JSON object: {exc}"
         )
+
     return value
 
 
@@ -194,7 +202,7 @@ class AppVariant(BaseSettingsModel):
         default="{}",
         title="Environment",
         widget="textarea",
-        syntax="json",
+        syntax=JSON_SYNTAX,
     )
     redirect_output: bool = SettingsField(
         default=True, title="Redirect output to Process Monitor",
@@ -217,7 +225,7 @@ class AppGroup(BaseSettingsModel):
         default="{}",
         title="Environment",
         widget="textarea",
-        syntax="json",
+        syntax=JSON_SYNTAX,
     )
 
     variants: list[AppVariant] = SettingsField(
@@ -247,7 +255,7 @@ class AdditionalAppGroup(BaseSettingsModel):
         default="{}",
         title="Environment",
         widget="textarea",
-        syntax="json",
+        syntax=JSON_SYNTAX,
     )
 
     variants: list[AppVariant] = SettingsField(
@@ -281,7 +289,7 @@ class ToolVariantModel(BaseSettingsModel):
         default="{}",
         title="Environments",
         widget="textarea",
-        syntax="json",
+        syntax=JSON_SYNTAX,
     )
 
     @validator("environment")
@@ -296,7 +304,7 @@ class ToolGroupModel(BaseSettingsModel):
         default="{}",
         title="Environments",
         widget="textarea",
-        syntax="json",
+        syntax=JSON_SYNTAX,
     )
     variants: list[ToolVariantModel] = SettingsField(default_factory=list)
 


### PR DESCRIPTION
## Changelog Description
allow comments and trailing commas in environment configs 

## Additional review information
code wise this is mostly just this (for now)
```py
try:
    import json5 as json
except ImportError:
    import json
```
but there are probably a few more places that might need minor adjustments.

I'm just putting this PR out here as a wip / idea up for discussion

<img width="1089" height="618" alt="image" src="https://github.com/user-attachments/assets/0b91ef40-1034-4d6b-bb8a-1f99334e1fd8" />
