### PR TITLE
Chore: Disable listening to all nodes to update workfiles

### DIFF
--- a/server/addon.py
+++ b/server/addon.py
@@ -139,7 +139,7 @@ class ApplicationsAddon(BaseServerAddon):
         EventStream.subscribe(
             "bundle.updated",
             self._on_bundle_updated,
-            all_nodes=True,
+            all_nodes=False,
         )
 
     async def get_simple_actions(


### PR DESCRIPTION
## Changelog Description
Workfiles are auto-filled with host name only on the node which triggered bundle change.

### Traceback
```
server-2        | 
postgres-1      | 2026-02-06 11:25:11.612 CET [543346] ERROR:  duplicate key value violates unique constraint "addon_data_pkey"
postgres-1      | 2026-02-06 11:25:11.612 CET [543346] DETAIL:  Key (addon_name, addon_version, key)=(applications, 1.3.2, workfile_entities_host_name_filled) already exists.
postgres-1      | 2026-02-06 11:25:11.612 CET [543346] STATEMENT:  INSERT INTO public.addon_data (addon_name, addon_version, key, data) VALUES ($1, $2, $3, $4)
server-1        | ERROR   logging                    | Error in global event handler '_on_bundle_updated'
server-1        |     traceback:
server-1        |       asyncpg.exceptions.UniqueViolationError: duplicate key value violates unique constraint "addon_data_pkey"
server-1        |       DETAIL:  Key (addon_name, addon_version, key)=(applications, 1.3.2, workfile_entities_host_name_filled) already exists.
server-1        | 
server-1        |       ayon_server/api/messaging.py:43
server-1        |       await handler(event)
server-1        | 
server-1        |       /addons/applications/1.3.2/server/addon.py:544
server-1        |       await self._autofill_workfile_entities()
server-1        | 
server-1        |       /addons/applications/1.3.2/server/addon.py:582
server-1        |       await Postgres.execute(
server-1        | 
server-1        |       ayon_server/lib/postgres.py:209
server-1        |       return await connection.execute(query, *args, timeout=timeout)
server-1        | 
server-1        |       asyncpg/protocol/protocol.pyx:205
server-1        | 
postgres-1      | 2026-02-06 11:25:11.623 CET [543940] ERROR:  duplicate key value violates unique constraint "addon_data_pkey"
postgres-1      | 2026-02-06 11:25:11.623 CET [543940] DETAIL:  Key (addon_name, addon_version, key)=(applications, 1.3.2, workfile_entities_host_name_filled) already exists.
postgres-1      | 2026-02-06 11:25:11.623 CET [543940] STATEMENT:  INSERT INTO public.addon_data (addon_name, addon_version, key, data) VALUES ($1, $2, $3, $4)
server-2        | ERROR   logging                    | Error in global event handler '_on_bundle_updated'
server-2        |     traceback:
server-2        |       asyncpg.exceptions.UniqueViolationError: duplicate key value violates unique constraint "addon_data_pkey"
server-2        |       DETAIL:  Key (addon_name, addon_version, key)=(applications, 1.3.2, workfile_entities_host_name_filled) already exists.
server-2        | 
server-2        |       ayon_server/api/messaging.py:43
server-2        |       await handler(event)
server-2        | 
server-2        |       /addons/applications/1.3.2/server/addon.py:544
server-2        |       await self._autofill_workfile_entities()
server-2        | 
server-2        |       /addons/applications/1.3.2/server/addon.py:582
server-2        |       await Postgres.execute(
server-2        | 
server-2        |       ayon_server/lib/postgres.py:209
server-2        |       return await connection.execute(query, *args, timeout=timeout)
server-2        | 
server-2        |       asyncpg/protocol/protocol.pyx:205
server-2        | 
```
## Testing notes:
1. This can be tested only on multi-node setup and if you have workfile entities without filled host name.
2. Change production bundle to one with this version.
3. Only one of them should actually propagate the host name to workfile entities.
