### PR TITLE
Fix: use last published workfile

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -773,7 +773,7 @@ def _prepare_last_workfile(
                 workdir, file_template, workdir_data, extensions, True
             )
 
-            # Optionally copy last published workfile into workdir before launch
+            # Copy last published workfile into workdir before launch
             use_published = should_copy_last_published_workfile_on_launch(
                 project_name,
                 app.host_name,


### PR DESCRIPTION
## Changelog Description
Fix logic for existing `use_last_published_workfile` setting.

## Additional info
Fixes https://github.com/ynput/ayon-core/issues/1346

## Testing notes:
1. 1. Checkout the `ayon-core` addon to the branch related to this PR: https://github.com/ynput/ayon-core/pull/1698
2. Enable the `ayon+settings://core/tools/Workfiles/last_workfile_on_startup/0/use_last_published_workfile` setting
3. Launch a task from which workfiles has been published but you don't have local workfiles or the local workfile is older than the last published one.
