### PR TITLE
Group label per variant

### DIFF
--- a/server/actions.py
+++ b/server/actions.py
@@ -62,12 +62,15 @@ def get_items_for_app_groups(groups):
             variant_name = variant["name"]
             if not variant_name:
                 continue
+            variant_group_label = variant["group_label"]
+            if not variant_group_label:
+                variant_group_label = group_label
             variant_label = variant["label"] or variant_name
             full_name = f"{group_name}/{variant_name}"
             items.append({
                 "host_name": group["host_name"],
                 "value": full_name,
-                "group_label": group_label,
+                "group_label": variant_group_label,
                 "variant_label": variant_label,
                 "icon": icon,
             })

--- a/server/settings.py
+++ b/server/settings.py
@@ -188,11 +188,8 @@ class AppVariant(BaseSettingsModel):
     group_label: str = SettingsField(
         "",
         title="Group label",
-        placeholder="Leave empty to use group label",
-        description=(
-            "Group label used for UI purposes."
-            " If not set, label from group is used."
-        ),
+        placeholder="Override group label for this variant",
+        description="Override group label used for UI purposes.",
     )
     executables: MultiplatformStrList = SettingsField(
         default_factory=MultiplatformStrList, title="Executables"

--- a/server/settings.py
+++ b/server/settings.py
@@ -185,6 +185,15 @@ class MultiplatformStrList(BaseSettingsModel):
 class AppVariant(BaseSettingsModel):
     name: str = SettingsField("", title="Name")
     label: str = SettingsField("", title="Label")
+    group_label: str = SettingsField(
+        "",
+        title="Group label",
+        placeholder="Leave empty to use group label",
+        description=(
+            "Group label used for UI purposes."
+            " If not set, label from group is used."
+        ),
+    )
     executables: MultiplatformStrList = SettingsField(
         default_factory=MultiplatformStrList, title="Executables"
     )


### PR DESCRIPTION
## Changelog Description
Added option to change group label per variant.

## Additional review information
This gives option to split Houdini variants into their own categories as needed.

## Testing notes:
1. Define custom group label on an application variant.
2. The action in UI should show the group (e.g in launcher).

Resolves https://github.com/ynput/ayon-applications/issues/142