### PR TITLE
Actions: Sort actions by settings order

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -9,8 +9,6 @@ import logging
 import typing
 from typing import Optional, Any
 
-import ayon_api
-
 from ayon_core import AYON_CORE_ROOT
 from ayon_core.settings import get_project_settings
 from ayon_core.lib import Logger, get_ayon_username, filter_profiles
@@ -315,21 +313,12 @@ def get_applications_for_context(
         project_settings = get_project_settings(project_name)
     apps_settings = project_settings["applications"]
 
-    # Use attributes to get available applications
-    # - this is older source of the information, will be deprecated in future
-    project_applications = apps_settings["project_applications"]
-    if not project_applications["enabled"]:
-        if project_entity is None:
-            project_entity = ayon_api.get_project(project_name)
-        apps = project_entity["attrib"].get("applications")
-        return apps or []
-
     task_type = None
     if task_entity:
         task_type = task_entity["taskType"]
 
     profile = filter_profiles(
-        project_applications["profiles"],
+        apps_settings["project_applications"]["profiles"],
         {"task_types": task_type}
     )
     if profile:
@@ -361,19 +350,6 @@ def get_tools_for_context(
         project_settings = get_project_settings(project_name)
     apps_settings = project_settings["applications"]
 
-    project_tools = apps_settings["project_tools"]
-    # Use attributes to get available tools
-    # - this is older source of the information, will be deprecated in future
-    if not project_tools["enabled"]:
-        tools = None
-        if task_entity:
-            tools = task_entity["attrib"].get("tools")
-
-        if tools is None and folder_entity:
-            tools = folder_entity["attrib"].get("tools")
-
-        return tools or []
-
     folder_path = task_type = task_name = None
     if folder_entity:
         folder_path = folder_entity["path"]
@@ -382,7 +358,7 @@ def get_tools_for_context(
         task_name = task_entity["name"]
 
     profile = filter_profiles(
-        project_tools["profiles"],
+        apps_settings["project_tools"]["profiles"],
         {
             "folder_paths": folder_path,
             "task_types": task_type,

--- a/server/actions.py
+++ b/server/actions.py
@@ -63,16 +63,6 @@ def _get_task_types_by_app_name(
         for task_type in project_entity.task_types
     }
     task_types_by_app_name = collections.defaultdict(set)
-    if not addon_settings["project_applications"]["enabled"]:
-        project_apps = project_entity.original_attributes.get(
-            "applications", []
-        )
-        for app_full_name in app_items_by_name.keys():
-            if app_full_name in project_apps:
-                task_types_by_app_name[app_full_name] |= (
-                    project_task_types.copy()
-                )
-        return task_types_by_app_name
 
     profiles = copy.deepcopy(
         addon_settings["project_applications"]["profiles"]

--- a/server/actions.py
+++ b/server/actions.py
@@ -1,4 +1,3 @@
-import collections
 import copy
 import typing
 from typing import Any
@@ -51,49 +50,6 @@ def _get_app_items_by_name(
         item.full_name: item
         for item in get_application_items(addon_settings)
     }
-
-
-def _get_task_types_by_app_name(
-    app_items_by_name: dict[str, ApplicationItem],
-    addon_settings: dict[str, Any],
-    project_entity: ProjectEntity
-) -> dict[str, set[str]]:
-    project_task_types = {
-        task_type["name"]
-        for task_type in project_entity.task_types
-    }
-    task_types_by_app_name = collections.defaultdict(set)
-
-    profiles = copy.deepcopy(
-        addon_settings["project_applications"]["profiles"]
-    )
-
-    generic_apps = None
-    used_task_types = set()
-    for profile in profiles:
-        allowed_apps = set(app_items_by_name.keys())
-        if profile["allow_type"] != "all_applications":
-            allowed_apps &= set(profile["applications"])
-
-        if not profile["task_types"]:
-            if generic_apps is None:
-                generic_apps = allowed_apps
-            continue
-
-        task_types = set(profile["task_types"]) - used_task_types
-        if not task_types:
-            continue
-
-        for app_name in allowed_apps:
-            task_types_by_app_name[app_name] |= task_types
-
-        used_task_types |= task_types
-
-    generic_task_types = project_task_types - used_task_types
-    if generic_task_types and generic_apps:
-        for app_name in generic_apps:
-            task_types_by_app_name[app_name] |= generic_task_types
-    return task_types_by_app_name
 
 
 def _get_app_names_by_task_type(
@@ -240,15 +196,11 @@ async def get_dynamic_action_manifests(
 
     app_items_by_name = _get_app_items_by_name(addon_settings)
 
-    task_types_by_app_name = _get_task_types_by_app_name(
+    app_names_by_task_type = _get_app_names_by_task_type(
         app_items_by_name,
         addon_settings,
         project_entity,
     )
-    app_names_by_task_type = collections.defaultdict(set)
-    for app_name, task_types in task_types_by_app_name.items():
-        for task_type in task_types:
-            app_names_by_task_type[task_type].add(app_name)
 
     task_ids = {
         workfile_entity.task_id

--- a/server/actions.py
+++ b/server/actions.py
@@ -106,6 +106,50 @@ def _get_task_types_by_app_name(
     return task_types_by_app_name
 
 
+def _get_app_names_by_task_type(
+    app_items_by_name: dict[str, ApplicationItem],
+    addon_settings: dict[str, Any],
+    project_entity: ProjectEntity
+) -> dict[str, list[str]]:
+    profiles = copy.deepcopy(
+        addon_settings["project_applications"]["profiles"]
+    )
+
+    default_profile = None
+    profiles_by_task_type = {}
+    for profile in profiles:
+        if not profile["task_types"]:
+            if default_profile is None:
+                default_profile = profile
+            continue
+
+        for task_type in profile["task_types"]:
+            profiles_by_task_type.setdefault(task_type, profile)
+
+    app_names_by_task_type = {
+        task_type["name"]: []
+        for task_type in project_entity.task_types
+    }
+    for task_type in project_entity.task_types:
+        task_type_name = task_type["name"]
+        task_type_profile = profiles_by_task_type.get(task_type_name)
+        if task_type_profile is None:
+            task_type_profile = default_profile
+            if task_type_profile is None:
+                continue
+
+        if task_type_profile["allow_type"] == "all_applications":
+            profile_apps = list(app_items_by_name.keys())
+            profile_apps.sort()
+        else:
+            profile_apps = list(task_type_profile["applications"])
+
+        if profile_apps:
+            app_names_by_task_type[task_type_name] = profile_apps
+
+    return app_names_by_task_type
+
+
 async def get_action_manifests(
     addon: "ApplicationsAddon",
     project_name: str,
@@ -123,7 +167,7 @@ async def get_action_manifests(
 
     app_items_by_name = _get_app_items_by_name(addon_settings)
 
-    task_types_by_app_name = _get_task_types_by_app_name(
+    app_names_by_task_type = _get_app_names_by_task_type(
         app_items_by_name,
         addon_settings,
         project_entity,
@@ -153,23 +197,22 @@ async def get_action_manifests(
             value=False,
         )
 
-    for app_name, task_types in task_types_by_app_name.items():
-        if not task_types:
-            continue
-        app_item = app_items_by_name[app_name]
-        output.append(
-            SimpleActionManifest(
-                identifier=f"{IDENTIFIER_PREFIX}{app_name}",
-                **_prepare_label_kwargs(app_item),
-                category="Applications",
-                icon=app_item.icon,
-                order=0,
-                entity_type="task",
-                entity_subtypes=list(task_types),
-                allow_multiselection=False,
-                **kwargs
+    for task_type, app_names in app_names_by_task_type.items():
+        for app_name in app_names:
+            app_item = app_items_by_name[app_name]
+            output.append(
+                SimpleActionManifest(
+                    identifier=f"{IDENTIFIER_PREFIX}{app_name}",
+                    **_prepare_label_kwargs(app_item),
+                    category="Applications",
+                    icon=app_item.icon,
+                    order=0,
+                    entity_type="task",
+                    entity_subtypes=[task_type],
+                    allow_multiselection=False,
+                    **kwargs
+                )
             )
-        )
     return output
 
 

--- a/server/addon.py
+++ b/server/addon.py
@@ -15,7 +15,6 @@ from ayon_server.events import EventStream, EventModel
 from ayon_server.addons import BaseServerAddon, AddonLibrary
 from ayon_server.actions.config import set_action_config
 from ayon_server.actions.context import ActionContext
-from ayon_server.entities.core import attribute_library
 from ayon_server.entities.user import UserEntity
 from ayon_server.helpers.project_list import get_project_list
 from ayon_server.bundles.project_bundles import (
@@ -42,7 +41,6 @@ if TYPE_CHECKING:
         DynamicActionManifest,
     )
 
-from .constants import LABELS_BY_GROUP_NAME
 from .settings import (
     ApplicationsAddonSettings,
     DEFAULT_VALUES,

--- a/server/addon.py
+++ b/server/addon.py
@@ -2,25 +2,6 @@
 
 This module contains the server side of the Applications addon.
 It is responsible for managing settings and initial setup of addon.
-
-## Attributes backward compatibility
-Current and previous versions of applications addon did use AYON attributes
-to define applications and tools for a project and task.
-
-This system was replaced with a new system using settings. This change is
-not 100% backwards compatible, we need to make sure that older versions of
-the addon don't break initialization.
-
-Older versions of the addon used settings of other versions, but
-the settings structure did change which can cause that combination of old
-and new Applications addon on server can cause crashes.
-
-First version introduction settings does support both settings and attributes
-so the handling of older versions is part of the addon, but following versions
-have to find some clever way how to avoid the issues.
-
-Version stored under 'ATTRIBUTES_VERSION_MILESTONE' should be last released
-version that used only old attribute system.
 """
 import os
 from typing import Any
@@ -80,8 +61,6 @@ from .actions import (
     IDENTIFIER_WORKFILE_PREFIX,
     DEBUG_TERMINAL_ID,
 )
-
-ATTRIBUTES_VERSION_MILESTONE = (1, 0, 0)
 
 HOST_TO_EXT_MAPPING = {
     "aftereffects": {".aep"},
@@ -250,29 +229,6 @@ class ApplicationsAddon(BaseServerAddon):
     async def get_default_settings(self):
         return self.get_settings_model()(**DEFAULT_VALUES)
 
-    async def pre_setup(self):
-        """Make sure older version of addon use the new way of attributes."""
-
-        instance = AddonLibrary.getinstance()
-        app_defs = instance.data.get(self.name)
-        old_addon = app_defs.versions.get("0.1.0")
-        if old_addon is not None:
-            # Override 'create_applications_attribute' for older versions
-            #   - avoid infinite server restart loop
-            old_addon.create_applications_attribute = (
-                self.create_applications_attribute
-            )
-
-        # Update older versions of applications addon to use new
-        #   '_update_enums'
-        # - new function skips newer addon versions without 'has_attributes'
-        version_objs, _invalid_versions = parse_versions(app_defs.versions)
-        for addon_version, version_obj in version_objs:
-            # Last release with only old attribute system
-            if version_obj < ATTRIBUTES_VERSION_MILESTONE:
-                addon = app_defs.versions[addon_version]
-                addon._update_enums = self._update_enums
-
     async def create_action_config_hash(
         self,
         identifier: str,
@@ -335,26 +291,6 @@ class ApplicationsAddon(BaseServerAddon):
                 project_name=context.project_name,
                 user_name=user.name,
             )
-
-    async def convert_settings_overrides(
-        self,
-        source_version: str,
-        overrides: dict[str, Any],
-    ) -> dict[str, Any]:
-        overrides = await super().convert_settings_overrides(
-            source_version, overrides
-        )
-        # Since 1.0.0 the project applications and tools are
-        #   using settings instead of attributes.
-        # Disable automatically project applications and tools
-        #   when converting settings of version < 1.0.0 so we don't break
-        #   productions on update
-        if parse_version(source_version) < (1, 0, 0):
-            prj_apps = overrides.setdefault("project_applications", {})
-            prj_apps["enabled"] = False
-            prj_tools = overrides.setdefault("project_tools", {})
-            prj_tools["enabled"] = False
-        return overrides
 
     async def get_application_items(
         self, project_name: str | None, variant: str
@@ -489,179 +425,6 @@ class ApplicationsAddon(BaseServerAddon):
         if hasattr(addon, "get_tool_items"):
             return await addon.get_tool_items(project_name, variant)
         return []
-
-    # --------------------------------------
-    # Backwards compatibility for attributes
-    # --------------------------------------
-    def _sort_versions(self, addon_versions, reverse=False):
-        version_objs, invalid_versions = parse_versions(addon_versions)
-
-        valid_versions = [
-            addon_version
-            for addon_version, version_obj in (
-                sorted(version_objs, key=lambda x: x[1])
-            )
-        ]
-        sorted_versions = list(sorted(invalid_versions)) + valid_versions
-        if reverse:
-            sorted_versions = reversed(sorted_versions)
-        for addon_version in sorted_versions:
-            yield addon_version
-
-    def _merge_groups(self, output, new_groups):
-        groups_by_name = {
-            o_group["name"]: o_group
-            for o_group in output
-        }
-        extend_groups = []
-        for new_group in new_groups:
-            group_name = new_group["name"]
-            if group_name not in groups_by_name:
-                extend_groups.append(new_group)
-                continue
-            existing_group = groups_by_name[group_name]
-            existing_variants = existing_group["variants"]
-            existing_variants_by_name = {
-                variant["name"]: variant
-                for variant in existing_variants
-            }
-            for new_variant in new_group["variants"]:
-                if new_variant["name"] not in existing_variants_by_name:
-                    existing_variants.append(new_variant)
-
-        output.extend(extend_groups)
-
-    def _get_enum_items_from_groups(self, groups):
-        label_by_name = {}
-        for group in groups:
-            group_name = group["name"]
-            group_label = group.get(
-                "label", LABELS_BY_GROUP_NAME.get(group_name)
-            ) or group_name
-            for variant in group["variants"]:
-                variant_name = variant["name"]
-                if not variant_name:
-                    continue
-                variant_label = variant["label"] or variant_name
-                full_name = f"{group_name}/{variant_name}"
-                full_label = f"{group_label} {variant_label}"
-                label_by_name[full_name] = full_label
-
-        return [
-            {"value": full_name, "label": label_by_name[full_name]}
-            for full_name in sorted(label_by_name)
-        ]
-
-    def _addon_has_attributes(self, addon, addon_version):
-        version_obj = parse_version(addon_version)
-        if version_obj is None or version_obj < ATTRIBUTES_VERSION_MILESTONE:
-            return True
-
-        return getattr(addon, "has_attributes", False)
-
-    async def _update_enums(self):
-        """Updates applications and tools enums based on the addon settings.
-        This method is called when the addon is started (after we are sure
-        that the 'applications' and 'tools' attributes exist) and when
-        the addon settings are updated (using on_settings_updated method).
-        """
-
-        instance = AddonLibrary.getinstance()
-        app_defs = instance.data.get(self.name)
-        all_applications = []
-        all_tools = []
-        for addon_version in self._sort_versions(
-            app_defs.versions.keys(), reverse=True
-        ):
-            addon = app_defs.versions[addon_version]
-            if not self._addon_has_attributes(addon, addon_version):
-                continue
-
-            for variant in ("production", "staging"):
-                settings_model = await addon.get_studio_settings(variant)
-                studio_settings = settings_model.dict()
-                application_settings = studio_settings["applications"]
-                app_groups = application_settings.pop("additional_apps")
-                for group_name, value in application_settings.items():
-                    value["name"] = group_name
-                    app_groups.append(value)
-                self._merge_groups(all_applications, app_groups)
-                self._merge_groups(all_tools, studio_settings["tool_groups"])
-
-        apps_attrib_name = "applications"
-        tools_attrib_name = "tools"
-
-        apps_enum = self._get_enum_items_from_groups(all_applications)
-        tools_enum = self._get_enum_items_from_groups(all_tools)
-
-        apps_attribute_data = {
-            "type": "list_of_strings",
-            "title": "Applications",
-            "enum": apps_enum,
-        }
-        tools_attribute_data = {
-            "type": "list_of_strings",
-            "title": "Tools",
-            "enum": tools_enum,
-        }
-
-        apps_scope = ["project"]
-        tools_scope = ["project", "folder", "task"]
-
-        apps_matches = False
-        tools_matches = False
-
-        async for row in Postgres.iterate(
-            "SELECT name, position, scope, data from public.attributes"
-        ):
-            if row["name"] == apps_attrib_name:
-                # Check if scope is matching ftrack addon requirements
-                if (
-                    set(row["scope"]) == set(apps_scope)
-                    and row["data"].get("enum") == apps_enum
-                ):
-                    apps_matches = True
-
-            elif row["name"] == tools_attrib_name:
-                if (
-                    set(row["scope"]) == set(tools_scope)
-                    and row["data"].get("enum") == tools_enum
-                ):
-                    tools_matches = True
-
-        if apps_matches and tools_matches:
-            return
-
-        if not apps_matches:
-            await Postgres.execute(
-                """
-                UPDATE attributes SET
-                    scope = $1,
-                    data = $2
-                WHERE
-                    name = $3
-                """,
-                apps_scope,
-                apps_attribute_data,
-                apps_attrib_name,
-            )
-
-        if not tools_matches:
-            await Postgres.execute(
-                """
-                UPDATE attributes SET
-                    scope = $1,
-                    data = $2
-                WHERE
-                    name = $3
-                """,
-                tools_scope,
-                tools_attribute_data,
-                tools_attrib_name,
-            )
-
-        # Reset attributes cache on server
-        await attribute_library.load()
 
     # --------------------------------------------
     # Auto-fill of host_name in workfiles entities

--- a/server/settings.py
+++ b/server/settings.py
@@ -520,15 +520,6 @@ class ProjectToolsProfile(BaseSettingsModel):
 
 
 class ProjectApplicationsModel(BaseSettingsModel):
-    enabled: bool = SettingsField(
-        True,
-        title="Use Applications profiles instead of attribute",
-        description=(
-            "Use applications attribute on the project instead of these"
-            " profiles. Attribute based applications will"
-            " be deprecated in future versions of applications addon."
-        ),
-    )
     profiles: list[ProjectApplicationsProfile] = SettingsField(
         default_factory=list,
         title="Profiles",
@@ -536,15 +527,6 @@ class ProjectApplicationsModel(BaseSettingsModel):
 
 
 class ProjectToolsModel(BaseSettingsModel):
-    enabled: bool = SettingsField(
-        True,
-        title="Use Tools profiles instead of attribute",
-        description=(
-            "Use tools attribute on folders and tasks instead of these"
-            " profiles. Attribute based tools will"
-            " be deprecated in future versions of applications addon."
-        ),
-    )
     profiles: list[ProjectToolsProfile] = SettingsField(
         default_factory=list,
         title="Profiles",
@@ -610,7 +592,6 @@ def _get_tools_defaults():
 
 
 DEFAULT_VALUES = {
-    "only_available": True,
     "project_applications": {
         "profiles": [
             {

--- a/server/settings.py
+++ b/server/settings.py
@@ -489,6 +489,7 @@ class ProjectApplicationsProfile(BaseSettingsModel):
         default_factory=list,
         title="Applications",
         description="Applications available for filtered context",
+        widget="sortable_multiselect",
         enum_resolver=applications_enum,
     )
 


### PR DESCRIPTION
## Changelog Description
Respect order of applications defined in settings, with that stop support of applications attribute.

## Additional review information
Multiple changes were required to support this.
- One being that `applications` and `tools` attributes are not longer supported -> removed related settings and related code.
- Profiles has to be fully resolved per project task type. Actions has to be defined per task type to keep ordering of applications. It will multiply the number of action manifests defined by applications addon but it works.

## Testing notes:
NOTE: At this moment this does NOT affect launcher tool.
1. Define applications in `ayon+settings://applications/project_applications/profiles`
2. They should be shown in web UI in the order defined in the settings.
3. Change order of applciations in the very same settings.
4. Again the order should change in web UI.

Resolves https://github.com/ynput/ayon-applications/issues/117