### PR TITLE
Settings: Name validations

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -226,6 +226,17 @@ class AppVariant(BaseSettingsModel):
         )
     )
 
+    @validator("name")
+    def validate_name(cls, value):
+        if not value:
+            raise BadRequestException("Application variant is empty")
+
+        if "/" in value:
+            raise BadRequestException(
+                f"Application variant ({value}) can't contain '/'"
+            )
+        return value
+
     @validator("environment")
     def validate_json(cls, value):
         return validate_json_dict(value)
@@ -278,6 +289,17 @@ class AdditionalAppGroup(BaseSettingsModel):
         section="Variants",
     )
 
+    @validator("name")
+    def validate_name(cls, value):
+        if not value:
+            raise BadRequestException("Application group name is empty")
+
+        if "/" in value:
+            raise BadRequestException(
+                f"Application group ({value}) can't contain '/'"
+            )
+        return value
+
     @validator("variants")
     def validate_unique_name(cls, value):
         ensure_unique_names(value)
@@ -305,6 +327,17 @@ class ToolVariantModel(BaseSettingsModel):
         syntax="json",
     )
 
+    @validator("name")
+    def validate_name(cls, value):
+        if not value:
+            raise BadRequestException("Tool variant is empty")
+
+        if "/" in value:
+            raise BadRequestException(
+                f"Tool variant ({value}) can't contain '/'"
+            )
+        return value
+
     @validator("environment")
     def validate_json(cls, value):
         return validate_json_dict(value)
@@ -320,6 +353,17 @@ class ToolGroupModel(BaseSettingsModel):
         syntax="json",
     )
     variants: list[ToolVariantModel] = SettingsField(default_factory=list)
+
+    @validator("name")
+    def validate_name(cls, value):
+        if not value:
+            raise BadRequestException("Tool group name is empty")
+
+        if "/" in value:
+            raise BadRequestException(
+                f"Tool group ({value}) can't contain '/'"
+            )
+        return value
 
     @validator("environment")
     def validate_json(cls, value):

--- a/server/settings.py
+++ b/server/settings.py
@@ -233,7 +233,7 @@ class AppVariant(BaseSettingsModel):
 
         if "/" in value:
             raise BadRequestException(
-                f"Application variant ({value}) can't contain '/'"
+                f"Application variant '{value}' can't contain '/'"
             )
         return value
 


### PR DESCRIPTION
## Changelog Description
Added simple validation of name values of applications and tools names.

## Additional review information
Make sure that applciations and tools names are not empty and do not contain `/` which is used for full name.

### Possible other issues/validations
- I could image `&` character could be also an issue for cli.
- Not sure if there are regex restrictions for webaction topic value (the name is part of the topic).

## Testing notes:
Validate code changes.
1. Using empty name or name with `/` should not allow to save settings.
