### PR TITLE
Settings defaults: Remove redundant labels

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -102,6 +102,7 @@
             "variants": [
                 {
                     "name": "2024",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Autodesk\\3ds Max 2024\\3dsmax.exe"
@@ -118,6 +119,7 @@
                 },
                 {
                     "name": "2023",
+                    "label": "",
                     "executables": {
                         "windows": [
                             "C:\\Program Files\\Autodesk\\3ds Max 2023\\3dsmax.exe"
@@ -208,7 +210,7 @@
             "variants": [
                 {
                     "name": "1.5.2",
-                    "label": "1.5.2",
+                    "label": "",
                     "show_grouped": true,
                     "executables": {
                         "windows": ["C:\\software\\gaffer-1.5.2.0-windows\\bin\\gaffer.cmd"],
@@ -1281,7 +1283,7 @@
             "variants": [
                 {
                     "name": "2025",
-                    "label": "2025",
+                    "label": "",
                     "show_grouped": true,
                     "executables": {
                         "windows": [
@@ -1584,7 +1586,7 @@
             "variants": [
                 {
                     "name": "5",
-                    "label": "5",
+                    "label": "",
                     "show_grouped": true,
                     "executables": {
                         "windows": [


### PR DESCRIPTION
## Changelog Description
Remove labels that are the same as app name.

## Testing notes:
1. Nothing should change.
