### PR TITLE
Add After Effects 2026 application variant

### DIFF
--- a/client/ayon_applications/version.py
+++ b/client/ayon_applications/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'applications' version."""
-__version__ = "1.3.6+dev"
+__version__ = "1.3.8+ae2026"

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "applications"
 title = "Applications"
-version = "1.3.6+dev"
+version = "1.3.8"
 
 client_dir = "ayon_applications"
 

--- a/server/applications.json
+++ b/server/applications.json
@@ -1158,6 +1158,26 @@
                         "linux": []
                     },
                     "environment": "{}"
+                },
+                {
+                    "name": "2026",
+                    "label": "",
+                    "show_grouped": true,
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Adobe\\Adobe After Effects 2026\\Support Files\\AfterFX.exe"
+                        ],
+                        "darwin": [
+                            "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+                        ],
+                        "linux": []
+                    },
+                    "arguments": {
+                        "windows": [],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{}"
                 }
             ]
         },


### PR DESCRIPTION
## Summary

Add After Effects 2026 (version 26.x) as a default application variant so studios running AE 2026 can launch it through the AYON launcher without manual settings configuration.

---

## Changes

- Add AE 2026 variant to the `aftereffects.variants` array in `applications.json`
- Windows path: `C:\Program Files\Adobe\Adobe After Effects 2026\Support Files\AfterFX.exe`
- macOS path: `/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app`
- Follows the existing naming convention (yearly release: 2023, 2024, 2025, 2026)

---

## Related Ticket(s)

[ENG-4376](https://halon.atlassian.net/browse/ENG-4376)

---

## Testing

1. Deploy the updated applications addon to an AYON server
2. Verify the AE 2026 variant appears in the Applications settings under After Effects
3. On a machine with AE 2026 installed, confirm it launches via the AYON launcher
4. Verify existing AE 2023/2024/2025 variants are unaffected