### PR TITLE
Add After Effects 2026 defaults

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -1158,6 +1158,26 @@
                         "linux": []
                     },
                     "environment": "{}"
+                },
+                {
+                    "name": "2026",
+                    "label": "",
+                    "show_grouped": true,
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Adobe\\Adobe After Effects 2026\\Support Files\\AfterFX.exe"
+                        ],
+                        "darwin": [
+                            "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+                        ],
+                        "linux": []
+                    },
+                    "arguments": {
+                        "windows": [],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{}"
                 }
             ]
         },


### PR DESCRIPTION
## Changelog Description

Add After Effects 2026 default application variant.

## Additional review information

Replaces: https://github.com/ynput/ayon-applications/pull/150

## Testing notes:

1. AFX 2026 should launch
