### PR TITLE
Add Nuke 16 and 17 defaults

### DIFF
--- a/server/applications.json
+++ b/server/applications.json
@@ -227,6 +227,50 @@
             "environment": "{}",
             "variants": [
                 {
+                    "name": "17.0",
+                    "label": "",
+                    "show_grouped": true,
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Nuke17.0v1\\Nuke17.0.exe"
+                        ],
+                        "darwin": [
+                            "/Applications/Nuke17.0v1/Nuke17.0v1.app"
+                        ],
+                        "linux": [
+                            "/usr/local/Nuke17.0v1/Nuke17.0"
+                        ]
+                    },
+                    "arguments": {
+                        "windows": [],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{}"
+                },
+                {
+                    "name": "16.0",
+                    "label": "",
+                    "show_grouped": true,
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Nuke16.0v4\\Nuke16.0.exe"
+                        ],
+                        "darwin": [
+                            "/Applications/Nuke16.0v4/Nuke16.0v4.app"
+                        ],
+                        "linux": [
+                            "/usr/local/Nuke16.0v4/Nuke16.0"
+                        ]
+                    },
+                    "arguments": {
+                        "windows": [],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{}"
+                },
+                {
                     "name": "15-0",
                     "label": "15.0",
                     "show_grouped": true,


### PR DESCRIPTION
## Changelog Description

Add Nuke 16 and 17 versions as application defaults

## Additional review information

Note that I've made the variant names use `.` instead of `-` for these new entries.

## Testing notes:

1. Nuke 16 should launch and work
2. Nuke 17 should launch and work
