### PR TITLE
Chore: Make sure the profile apps are available apps

### DIFF
--- a/server/actions.py
+++ b/server/actions.py
@@ -88,7 +88,11 @@ def _get_app_names_by_task_type(
             profile_apps = list(app_items_by_name.keys())
             profile_apps.sort()
         else:
-            profile_apps = list(task_type_profile["applications"])
+            profile_apps = [
+                app_name
+                for app_name in task_type_profile["applications"]
+                if app_name in app_items_by_name
+            ]
 
         if profile_apps:
             app_names_by_task_type[task_type_name] = profile_apps


### PR DESCRIPTION
## Changelog Description
Make sure that apps defined per task type are available actually apps.

## Additional review information
It can happen that applications defined in a profile are saved from previous settings version in that case the application is not available anymore and can cause that webactions are not collected correctly.

## Testing notes:
No idea how to test this. My guess is that you define a profile with e.g. `maya/2026`. Then remove `maya/2026` from Maya definitions. In that case the profile still has the app name in it, but the app definition is not available. If that happens webactions should be showed.
