### PR TITLE
Icons: Support full URLs

### DIFF
--- a/client/ayon_applications/addon.py
+++ b/client/ayon_applications/addon.py
@@ -7,6 +7,7 @@ import traceback
 import tempfile
 import warnings
 import typing
+import urllib.parse
 from typing import Optional, Any
 
 import ayon_api
@@ -190,6 +191,10 @@ class ApplicationsAddon(AYONAddon, IPluginPaths, ITrayAction):
     ) -> Optional[str]:
         """Get icon path.
 
+        icon filename can be either a full URL (http/https/file/...)
+        or a bare filename. Full URLs are used as is while bare filenames
+        resolve to the addons icons folder.
+
         Method does not validate if icon filename exist on server.
 
         Args:
@@ -203,6 +208,12 @@ class ApplicationsAddon(AYONAddon, IPluginPaths, ITrayAction):
         """
         if not icon_filename:
             return None
+
+        # check if its a full URL
+        url = urllib.parse.urlparse(icon_filename)
+        if url.scheme:
+            return icon_filename
+
         icon_name = os.path.basename(icon_filename)
         if server:
             base_url = ayon_api.get_base_url()

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import os
 from typing import Any
+import urllib.parse
 
 from .constants import LABELS_BY_GROUP_NAME, ICONS_BY_GROUP_NAME
 
@@ -61,14 +62,18 @@ def get_items_for_app_groups(groups):
         if not icon_name:
             icon_name = group.get("icon")
 
-        if icon_name:
-            icon_name = os.path.basename(icon_name)
-
         icon = None
         if icon_name:
+
+            url = urllib.parse.urlparse(icon_name)
+            if not url.scheme:
+                # it's a bare filename served from this addons public folder
+                icon_name = os.path.basename(icon_name)
+                icon_name = f"{{addon_url}}/public/icons/{icon_name}"
+
             icon = {
                 "type": "url",
-                "url": "{addon_url}/public/icons/" + icon_name,
+                "url": icon_name,
             }
 
         for variant in group["variants"]:


### PR DESCRIPTION
## Changelog Description
Support full urls for application icon's

## Additional review information
This PR allows icons to use full URL's in addition to regular filenames and therefor removes the need to build a custom version of the applications addon when adding "Additional Applications" as currently stated [here](https://help.ayon.app/articles/3945756-applications-and-tools#q4720b3m4kw)


## Testing notes:
1. configure an "Additional Application"
2. set the `Icon` to either a weburl or a local file _(not recommended for production, but easy to test for development)_
3. open the launcher and confirm the icon is showing for actions and workfiles


### icon from a `https` url
initially I was using `https://picsum.photos/200` from https://picsum.photos for testing, but the page went down the moment I was creating this PR...  so I've used https://ynput.io/wp-content/uploads/2022/09/ay-symbol-blackw-full.png instead. In a real production scenario I'd suggest using a self hosted file, for example from another addon
<img width="2137" height="1010" alt="image" src="https://github.com/user-attachments/assets/42e09a1d-328b-4d9f-bdf1-b907866f8fab" />

### icon using a local path
(not advised for production)
<img width="2017" height="1012" alt="image" src="https://github.com/user-attachments/assets/fd79fe50-992a-4437-b755-211c5b387223" />



