### PR TITLE
Feature: Add workfile args app env for context

### DIFF
--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -179,7 +179,8 @@ def get_app_environments_for_context(
     launch_type: Optional[str] = None,
     env: Optional[dict[str, str]] = None,
     addons_manager: Optional[AddonsManager] = None,
-    start_last_workfile: bool = False,
+    workfile_path: Optional[str] = None,
+    start_last_workfile: Optional[bool] = None,
 ) -> dict[str, str]:
     """Prepare environment variables by context.
     Args:
@@ -196,7 +197,8 @@ def get_app_environments_for_context(
             `os.environ` is used when not passed.
         addons_manager (Optional[AddonsManager]): Initialized modules
             manager.
-        start_last_workfile (bool): Whether to start last workfile.
+        workfile_path (Optional[str]): Workfile path to open.
+        start_last_workfile (Optional[bool]): Whether to start last workfile.
 
     Returns:
         dict: Environments for passed context and application.
@@ -214,6 +216,7 @@ def get_app_environments_for_context(
         env=env,
         addons_manager=addons_manager,
         modules_manager=addons_manager,
+        workfile_path=workfile_path,
         start_last_workfile=start_last_workfile,
     )
     context.run_prelaunch_hooks()

--- a/client/ayon_applications/utils.py
+++ b/client/ayon_applications/utils.py
@@ -179,6 +179,7 @@ def get_app_environments_for_context(
     launch_type: Optional[str] = None,
     env: Optional[dict[str, str]] = None,
     addons_manager: Optional[AddonsManager] = None,
+    start_last_workfile: bool = False,
 ) -> dict[str, str]:
     """Prepare environment variables by context.
     Args:
@@ -195,6 +196,7 @@ def get_app_environments_for_context(
             `os.environ` is used when not passed.
         addons_manager (Optional[AddonsManager]): Initialized modules
             manager.
+        start_last_workfile (bool): Whether to start last workfile.
 
     Returns:
         dict: Environments for passed context and application.
@@ -212,6 +214,7 @@ def get_app_environments_for_context(
         env=env,
         addons_manager=addons_manager,
         modules_manager=addons_manager,
+        start_last_workfile=start_last_workfile,
     )
     context.run_prelaunch_hooks()
     return context.env


### PR DESCRIPTION
## Changelog Description
Add `start_last_workfile` and `workfile_path` arguments to `get_app_environments_for_context`.

## Testing notes:
1. Call `get_app_environments_for_context` with a `workfile_path`.
2. Execute a launch and witness the workfile opening
3. Call `get_app_environments_for_context` with `start_last_workfile` to `True`
2. Execute a launch and witness the last local workfile opening